### PR TITLE
Fix, damit im BE Javascript-Einstellungen wieder editierbar sind

### DIFF
--- a/dca/tl_module.php
+++ b/dca/tl_module.php
@@ -221,7 +221,7 @@ array_insert($GLOBALS['TL_DCA']['tl_module']['fields'] , 2, array
 	    'default' 		=> '1000',
 	    'exclude' 		=> true,
 	    'inputType' 	=> 'text',
-	    'eval' 			=> array(),
+	    'eval' 			=> array('tl_class'=>'w50'),
 		'sql'			=> "varchar(55) NOT NULL default '1000'"
 	),
 	'srl_set_closePerEsc' => array


### PR DESCRIPTION
Dies ist der Fix, damit im Backend in den Javascript-Einstellungen die IDs wieder editiert werden können.

Sie auch #8 